### PR TITLE
Bump logback-classic from 1.1.1 to 1.2.0 in /seckill

### DIFF
--- a/seckill/pom.xml
+++ b/seckill/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.0</version>
     </dependency>
 
     <!-- 2.数据库相关依赖 -->


### PR DESCRIPTION
Bumps logback-classic from 1.1.1 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:production ...